### PR TITLE
Thermal neutron generation and hit tagging

### DIFF
--- a/NeutReflectometry.cc
+++ b/NeutReflectometry.cc
@@ -223,10 +223,11 @@ int main(int argc, char** argv) {
   // set manditory user action class
   // UserAction Classes
   NeutReflect_PrimaryGeneratorAction* myPrimaryEventGenerator;
-  if(cascaderootfile=="NULL")
-    myPrimaryEventGenerator=new NeutReflect_PrimaryGeneratorAction(xnbias,source);
-  else
-    myPrimaryEventGenerator=new NeutReflect_PrimaryGeneratorAction(xnbias,"cascade",cascaderootfile);
+  //if(cascaderootfile=="NULL")
+  //  myPrimaryEventGenerator=new NeutReflect_PrimaryGeneratorAction(xnbias,source);
+  //else
+  //  myPrimaryEventGenerator=new NeutReflect_PrimaryGeneratorAction(xnbias,"cascade",cascaderootfile);
+  myPrimaryEventGenerator=new NeutReflect_PrimaryGeneratorAction(xnbias,source,cascaderootfile);
   runManager->SetUserAction(myPrimaryEventGenerator);
   NeutReflect_RunAction* pRunAction = new NeutReflect_RunAction(myPrimaryEventGenerator);
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,0 +1,10 @@
+## Future pre-Releases (v0.1.2) Date XX.XX.XX 
+
+
+## pre-Release (v0.1.1) Date 22.01.21
+
+* PR #11 added thermal neutron sources (solves issue #8) 
+
+## pre-Release (v0.1.0) Date: 22.01.18
+
+* got CMake to work minimally (solves issue #7)

--- a/include/NeutReflect_DataStorage.hh
+++ b/include/NeutReflect_DataStorage.hh
@@ -24,7 +24,7 @@
 
 #include <list>
 
-#define N_DATA 18
+#define N_DATA 22 
 #define N_LENGTH 200000
 
 #ifdef ASCIIOUT

--- a/include/NeutReflect_DetectorConstruction.hh
+++ b/include/NeutReflect_DetectorConstruction.hh
@@ -95,6 +95,7 @@ private:
   G4Material* Steel;
   G4Material* Air;
   G4Material* Argon;
+  G4Material* Neon;
   G4Material* Aluminium;
 
   G4double BeR;
@@ -151,6 +152,7 @@ private:
   void ConstructR68SiDet(G4VPhysicalVolume*,G4double dist=400.0);
   void ConstructSNOLABDet(G4VPhysicalVolume*,G4String name, G4String mat="Ge",G4double dist=400.0);
   void ConstructArDet(G4VPhysicalVolume*,G4double dist=400.0);
+  void ConstructNeDet(G4VPhysicalVolume*,G4double dist=400.0);
   void ConstructGenericDet(G4VPhysicalVolume*,G4Material*,G4String name="gendet",G4double dist=400.0);
   void ConstructSimpleVessel(G4VPhysicalVolume*,G4double vthk=400.0,
 						G4double vrad=146.2,

--- a/include/NeutReflect_StdSD.hh
+++ b/include/NeutReflect_StdSD.hh
@@ -34,6 +34,7 @@ private:
   NeutReflect_StdHitsCollection* stdCollection;
   G4int genericNb;
 
+  G4bool isNCap(G4Track* track,G4Step *aStep);
   NeutReflect_PrimaryGeneratorAction *Ngen;
 
 };

--- a/src/NeutReflect_DataStorage.cc
+++ b/src/NeutReflect_DataStorage.cc
@@ -49,15 +49,15 @@ NeutReflect_DataStorage::NeutReflect_DataStorage(G4String filename, G4int run, G
   sprintf(myNames[0], "EV"); sprintf(myNames[1], "DT"); sprintf(myNames[2], "TS");
   sprintf(myNames[3], "P"); sprintf(myNames[4], "Type"); sprintf(myNames[5], "E1");
   sprintf(myNames[6], "D3");
-  sprintf(myNames[7], "X1"); sprintf(myNames[8], "Y1"); sprintf(myNames[9], "Z1");
+  sprintf(myNames[7], "PX3"); sprintf(myNames[8], "PY3"); sprintf(myNames[9], "PZ3");
   sprintf(myNames[10], "X3"); sprintf(myNames[11], "Y3"); sprintf(myNames[12], "Z3");
-  sprintf(myNames[13], "PX"); sprintf(myNames[14], "PY"); sprintf(myNames[15], "PZ");
-  sprintf(myNames[16], "time");
-  sprintf(myNames[17], "origevt");
-
+  sprintf(myNames[13], "time3");
+  sprintf(myNames[14], "PX1"); sprintf(myNames[15], "PY1"); sprintf(myNames[16], "PZ1");
+  sprintf(myNames[17], "X1"); sprintf(myNames[18], "Y1"); sprintf(myNames[19], "Z1");
+  sprintf(myNames[20], "time1");
+  sprintf(myNames[21], "nCap"); 
   for (int kk=0; kk<N_DATA; kk++)
     VariableNames[kk] = myNames[kk];
-
 
 #ifdef ASCIIOUT
 
@@ -124,15 +124,16 @@ void NeutReflect_DataStorage::writeArray()
   sprintf(myNames[0], "EV"); sprintf(myNames[1], "DT"); sprintf(myNames[2], "TS");
   sprintf(myNames[3], "P"); sprintf(myNames[4], "Type"); sprintf(myNames[5], "E1");
   sprintf(myNames[6], "D3");
-  sprintf(myNames[7], "X1"); sprintf(myNames[8], "Y1"); sprintf(myNames[9], "Z1");
+  sprintf(myNames[7], "PX3"); sprintf(myNames[8], "PY3"); sprintf(myNames[9], "PZ3");
   sprintf(myNames[10], "X3"); sprintf(myNames[11], "Y3"); sprintf(myNames[12], "Z3");
-  sprintf(myNames[13], "PX"); sprintf(myNames[14], "PY"); sprintf(myNames[15], "PZ");
-  sprintf(myNames[16], "time");
-  sprintf(myNames[17], "origevt");
+  sprintf(myNames[13], "time3");
+  sprintf(myNames[14], "PX1"); sprintf(myNames[15], "PY1"); sprintf(myNames[16], "PZ1");
+  sprintf(myNames[17], "X1"); sprintf(myNames[18], "Y1"); sprintf(myNames[19], "Z1");
+  sprintf(myNames[20], "time1");
+  sprintf(myNames[21], "nCap"); 
 
   for (int kk=0; kk<N_DATA; kk++)
     VariableNames[kk] = myNames[kk];
-
 
 
 #ifdef ASCIIOUT

--- a/src/NeutReflect_DetectorConstruction.cc
+++ b/src/NeutReflect_DetectorConstruction.cc
@@ -215,6 +215,14 @@ void NeutReflect_DetectorConstruction::DefineMaterials()
         Argon = new G4Material(name="Argon", density, nel=1, kStateGas);
         Argon->AddElement(elAr, 1.0);
  
+        //Neon
+        a = 20.18*g/mole;
+        G4Element* elNe = new G4Element(name="Neon", symbol="Ne", iz=10.0, a);
+        density = 0.89994*mg/cm3;
+        //STP is default so don't have to supply temp and press
+        Neon = new G4Material(name="Neon", density, nel=1, kStateGas);
+        Neon->AddElement(elNe, 1.0);
+
         //Steel (i.e. iron)
         a=55.845*g/mole;
         density=7.874*g/cm3;
@@ -499,6 +507,12 @@ G4VPhysicalVolume* NeutReflect_DetectorConstruction::Construct()
 	  //just a Si detector centered at zero
           ConstructR68SiDet(physicalWorld,0.0);
         }
+        else if(DesignNo==-14){
+          //construct Diag12
+	  //just a Ne detector centered at zero
+          ConstructNeDet(physicalWorld,0.0);
+        }
+        
 	
 	
 	
@@ -1497,6 +1511,41 @@ void NeutReflect_DetectorConstruction::ConstructArDet(G4VPhysicalVolume *world,G
         //make this sensitive
         if(ConstructGenericSensitiveInt>0){
           ConstructGenericSensitive(logicalArSphere,"ArDet");
+        }
+        return;
+}
+void NeutReflect_DetectorConstruction::ConstructNeDet(G4VPhysicalVolume *world,G4double dist)
+{
+        //only use rotation if parent volume is null (highest)
+        G4RotationMatrix *thisrot;
+        if(world->GetName()=="world_P")
+          thisrot=xrot;
+        else
+          thisrot=nullrot;
+
+	//make an argon sphere of 1 m at STP
+	//FIXME hardcoded size
+	G4Sphere* neSphere = new G4Sphere("neSphere_S",0.0,1000.0,0.0,2*pi,0.0,pi);
+	G4LogicalVolume* logicalNeSphere = new G4LogicalVolume(neSphere,Neon,"NeSph_L",0,0,0);
+	G4VPhysicalVolume* cylinderNeWorld = new G4PVPlacement(thisrot,
+								G4ThreeVector(0,-dist,0),
+								"NeSph_P",
+								logicalNeSphere,
+								world,
+								false,
+								0);
+
+	// Visualization attributes
+	G4VisAttributes* VisAttNeSph = new G4VisAttributes(G4Colour(255./255.,127./255.,80./255.));
+	VisAttNeSph->SetForceSolid(false);
+	//VisAttNeSph->SetForceWireframe(true);  //I want a Wireframe of the me
+	logicalNeSphere->SetVisAttributes(VisAttNeSph);  
+	// Make Invisible
+	//logicalCylinder->SetVisAttributes(G4VisAttributes::Invisible);
+
+        //make this sensitive
+        if(ConstructGenericSensitiveInt>0){
+          ConstructGenericSensitive(logicalNeSphere,"NeDet");
         }
         return;
 }

--- a/src/NeutReflect_EventAction.cc
+++ b/src/NeutReflect_EventAction.cc
@@ -141,7 +141,7 @@ void NeutReflect_EventAction::EndOfEventAction(const G4Event* evt)
 	       // modify the memory
 	       dataOut->getData()[1-1] = evt->GetEventID()+1;
                NeutReflect_EventInfo *anEventInfo = (NeutReflect_EventInfo*) evt->GetUserInformation();
-	       dataOut->getData()[18-1] = anEventInfo->GetBeLength();
+	       //dataOut->getData()[18-1] = anEventInfo->GetBeLength();
 
 	       // add this data to the matrix array
 	       dataOut->addData();

--- a/src/NeutReflect_PrimaryGeneratorAction.cc
+++ b/src/NeutReflect_PrimaryGeneratorAction.cc
@@ -39,7 +39,7 @@ decayer(dec),
 rootfile(rfile)
 {
   //initialize TTree pointer to NULL
-  t = NULL;
+  //t = NULL;
 
   //finalpathlength initialize
   finalpathlength = -1.0;
@@ -110,8 +110,8 @@ rootfile(rfile)
 }
 NeutReflect_PrimaryGeneratorAction::~NeutReflect_PrimaryGeneratorAction()
 {
-  if(decayer=="cascade" && rootfile=="NULL")
-    f->Close();
+  //if(decayer=="cascade" && rootfile=="NULL")
+  //  f->Close();
   delete particleGun;
 }
 void NeutReflect_PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)

--- a/src/NeutReflect_PrimaryGeneratorAction.cc
+++ b/src/NeutReflect_PrimaryGeneratorAction.cc
@@ -287,7 +287,7 @@ void NeutReflect_PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       //set the particle position
       particleGun->SetParticlePosition(G4ThreeVector(srcr*cos(srcthet)*mm,srcr*sin(srcthet)*mm,srcz*mm).transform(*xrot));
     }
-    else if(Ndet->GetDesignNo() == -9){
+    else if((Ndet->GetDesignNo() == -9) || (Ndet->GetDesignNo()==-14)){
       G4double srcr,srcthet,srcphi;
       //generate uniform in costhet
       srcthet=-1+2*G4UniformRand();

--- a/src/NeutReflect_StdHit.cc
+++ b/src/NeutReflect_StdHit.cc
@@ -21,7 +21,7 @@ G4Allocator<NeutReflect_StdHit> NeutReflect_StdHitAllocator;
 
 NeutReflect_StdHit::NeutReflect_StdHit() 
 {
-  dataVector = new G4double[18];
+  dataVector = new G4double[22];
 }
 NeutReflect_StdHit::NeutReflect_StdHit(const NeutReflect_StdHit& right) : G4VHit()
 {

--- a/working_command.md
+++ b/working_command.md
@@ -122,3 +122,9 @@ This is a command that works on my mac:
         }
 
 ```
+
+* NOTE: the following command produced nuclear recoils I think with a photoneutron source:
+
+```
+ ./NeutReflectometry -src 88Y -bias 10000 -d 1 -set 1 -ngen 100000 -otype txt -usestringlabel test -nomac -loc .
+```

--- a/working_command.md
+++ b/working_command.md
@@ -128,3 +128,17 @@ This is a command that works on my mac:
 ```
  ./NeutReflectometry -src 88Y -bias 10000 -d 1 -set 1 -ngen 100000 -otype txt -usestringlabel test -nomac -loc .
 ```
+
+* I've upgraded the code to be able to run pure capture events (from thermal neutron primaries). Here are the commands for that (v0.1.1 and above)
+
+```
+./NeutReflectometry -src cascade -d -9 -set 2 -ngen 100000 -otype ascii -usestringlabel ArCapture -nomac -loc .
+```
+
+```
+./NeutReflectometry -src cascade -d -8 -set 2 -ngen 100000 -otype ascii -usestringlabel SiCapture -nomac -loc .
+```
+
+```
+./NeutReflectometry -src cascade -d -7 -set 2 -ngen 100000 -otype ascii -usestringlabel GeCapture -nomac -loc .
+```

--- a/working_command.md
+++ b/working_command.md
@@ -142,3 +142,16 @@ This is a command that works on my mac:
 ```
 ./NeutReflectometry -src cascade -d -7 -set 2 -ngen 100000 -otype ascii -usestringlabel GeCapture -nomac -loc .
 ```
+
+*  some command-line filtration stuff:
+
+```
+(base) Anthonys-MacBook-Pro-2:G4PhysicsTesting_build villaa$ cat ./NROUT/NeutReflectDiag6_Sourcecascade_neutron_SiCapture_000_00*.txt |awk '{if($5==29014 && $6>0){print $5" "$6" "$7}}' |awk 'END{print NR}'
+5080
+(base) Anthonys-MacBook-Pro-2:G4PhysicsTesting_build villaa$ cat ./NROUT/NeutReflectDiag6_Sourcecascade_neutron_SiCapture_000_00*.txt |awk '{if($5==30014 && $6>0){print $5" "$6" "$7}}' |awk 'END{print NR}'
+1449
+(base) Anthonys-MacBook-Pro-2:G4PhysicsTesting_build villaa$ cat ./NROUT/NeutReflectDiag6_Sourcecascade_neutron_SiCapture_000_00*.txt |awk '{if($5==31014 && $6>0){print $5" "$6" "$7}}' |awk 'END{print NR}'
+62
+(base) Anthonys-MacBook-Pro-2:G4PhysicsTesting_build villaa$ cat ./NROUT/NeutReflectDiag6_Sourcecascade_neutron_SiCapture_000_00*.txt |awk '{if($5==32014 && $6>0){print $5" "$6" "$7}}' |awk 'END{print NR}'
+0
+```


### PR DESCRIPTION
Add thermal neutron sources when using `-src cascade` _without_ specifying an input file from `nrCascadeSim`

We have also added the hit outputs to 22 variables just like `villano-lab/k100Sim` and the last variable labels neutrons on their last step before capture by a `1` as opposed to `0`. 